### PR TITLE
feat: Sheets API integration (read-only + actions logging, behind flag)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,5 +1,6 @@
-NEXT_PUBLIC_API_BASE=
-NEXT_PUBLIC_API_KEY=
+NEXT_PUBLIC_USE_SHEETS=0
+NEXT_PUBLIC_SHEETS_API_BASE_URL=
+NEXT_PUBLIC_SHEETS_API_KEY=
 
 # We will point these to a Google Apps Script Web App that fronts Google Sheets
 # (Sheets = DB). Do not call any live API here; just wire the helpers.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install
 
 ## Local development workflow
 
-1. Copy `.env.local.example` to `.env.local` and fill in the Apps Script endpoint details (see below).
+1. Copy `.env.example` (or `.env.local.example`) to `.env.local` and fill in the Apps Script endpoint details (see below).
 2. Start the dev server with `npm run dev`.
 3. Edit `src/app/(ui)/prototype/page.tsx` to paste your Canvas prototype integration.
 4. Visit `http://localhost:3000/` and use the **Office** or **Floor** links to preview the embed in different routes.
@@ -29,10 +29,15 @@ The front-end talks to Google Sheets via a Google Apps Script Web App.
 
 | Variable | Description |
 | --- | --- |
-| `NEXT_PUBLIC_API_BASE` | Base URL of the Apps Script deployment that fronts Google Sheets. |
-| `NEXT_PUBLIC_API_KEY` | Optional API key header (`x-api-key`) for the Apps Script gateway. |
+| `NEXT_PUBLIC_USE_SHEETS` | Feature flag. Set to `1` to read/write via the Sheets Apps Script backend, otherwise the demo uses in-memory data. |
+| `NEXT_PUBLIC_SHEETS_API_BASE_URL` | Base URL of the Apps Script deployment that fronts Google Sheets. |
+| `NEXT_PUBLIC_SHEETS_API_KEY` | API key header (`x-api-key`) for the Apps Script gateway. |
 
 > Never commit a real `.env.local` file to the repository; use `.env.local.example` as a reference.
+
+## Backend (Sheets API)
+
+The optional Sheets-backed mode fetches masters, orders, and storage data from your Google Apps Script deployment while logging actions (保管, 使用, 廃棄, 分割). Enable it by setting `NEXT_PUBLIC_USE_SHEETS=1` and configuring `NEXT_PUBLIC_SHEETS_API_BASE_URL` + `NEXT_PUBLIC_SHEETS_API_KEY` in both your local `.env.local` and the Vercel project settings.
 
 ## Prototype host
 
@@ -43,7 +48,7 @@ UI primitives (button, dialog, card, etc.) live in `src/components/ui` and are p
 ## Deployment on Vercel
 
 1. Create a new project in Vercel and connect it to the GitHub repository that hosts this code.
-2. Set the `NEXT_PUBLIC_API_BASE` and `NEXT_PUBLIC_API_KEY` environment variables inside the Vercel project settings.
+2. Set `NEXT_PUBLIC_USE_SHEETS`, `NEXT_PUBLIC_SHEETS_API_BASE_URL`, and `NEXT_PUBLIC_SHEETS_API_KEY` inside the Vercel project settings.
 3. Vercel will run `npm run build` (configured in `vercel.json`) to produce the production build.
 
 ## Next steps checklist

--- a/src/lib/sheets/api.ts
+++ b/src/lib/sheets/api.ts
@@ -1,0 +1,28 @@
+import type { ActionBody, Masters, OrderRow, StorageAggRow } from './types';
+
+const BASE = process.env.NEXT_PUBLIC_SHEETS_API_BASE_URL!;
+const KEY  = process.env.NEXT_PUBLIC_SHEETS_API_KEY!;
+
+async function getJSON<T>(pathWithQuery: string): Promise<T> {
+  const url = `${BASE}?path=${encodeURIComponent(pathWithQuery)}&x-api-key=${encodeURIComponent(KEY)}`;
+  const res = await fetch(url, { cache: 'no-store' });
+  if (!res.ok) throw new Error(`GET ${pathWithQuery} failed: ${res.status}`);
+  return res.json();
+}
+
+async function postJSON<T>(body: ActionBody): Promise<T> {
+  const res = await fetch(BASE, {
+    method: 'POST',
+    headers: { 'Content-Type':'application/json', 'x-api-key': KEY },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`POST ${body?.path} failed: ${res.status}`);
+  return res.json();
+}
+
+export const sheetsApi = {
+  getMasters:     () => getJSON<Masters>('masters'),
+  getOrders:      (factory: string) => getJSON<OrderRow[]>(`orders&factory=${encodeURIComponent(factory)}&archived=false`),
+  getStorageAgg:  (factory: string) => getJSON<StorageAggRow[]>(`storage-agg&factory=${encodeURIComponent(factory)}`),
+  postAction:     (body: ActionBody) => postJSON(body),
+};

--- a/src/lib/sheets/hooks.ts
+++ b/src/lib/sheets/hooks.ts
@@ -1,0 +1,17 @@
+import useSWR from 'swr';
+import { sheetsApi } from './api';
+import type { Masters, OrderRow, StorageAggRow, ActionBody } from './types';
+
+export function useMasters(enabled = true) {
+  return useSWR<Masters>(enabled ? 'masters' : null, enabled ? () => sheetsApi.getMasters() : null, { revalidateOnFocus:false, dedupingInterval: 30*60*1000 });
+}
+export function useOrders(factory: string | undefined) {
+  return useSWR<OrderRow[]>(factory ? ['orders', factory] : null, () => sheetsApi.getOrders(factory!), { revalidateOnFocus:false });
+}
+export function useStorageAgg(factory: string | undefined) {
+  return useSWR<StorageAggRow[]>(factory ? ['storage-agg', factory] : null, () => sheetsApi.getStorageAgg(factory!), { revalidateOnFocus:false });
+}
+
+export async function postAction(body: ActionBody) {
+  return sheetsApi.postAction(body);
+}

--- a/src/lib/sheets/types.ts
+++ b/src/lib/sheets/types.ts
@@ -1,0 +1,44 @@
+export type UseType = 'fissule' | 'oem';
+
+export interface Factory { code: string; name: string }
+export interface Location { factory_code: string; location_name: string }
+export interface Flavor { id: string; flavorName: string; liquidName: string; packToGram: number; expiryDays: number }
+export interface RecipeRow { flavor_id: string; row_no: number; ingredient_name: string; qty: number; unit: string }
+export interface Masters {
+  factories: Factory[];
+  locations: Location[];
+  flavors: Flavor[];
+  recipes: RecipeRow[];
+  oems: string[];
+}
+
+export interface OrderRow {
+  order_id: string;
+  lot_id: string;
+  factory_code: string;
+  ordered_at: string;
+  flavor_id: string;
+  use_type: UseType;
+  packs: number;                // 0 if OEM
+  required_grams: number;
+  oem_partner?: string | null;
+  archived: boolean;
+}
+
+export interface StorageAggRow {
+  lot_id: string;
+  factory_code: string;
+  flavor_id: string;
+  grams: number;
+  locations: string[];          // aggregated list
+  manufactured_at: string;
+}
+
+export interface ActionBody {
+  path: 'action';
+  type: 'KEEP'|'USE'|'WASTE'|'MADE_SPLIT';
+  factory_code: string;
+  lot_id: string;
+  flavor_id: string;
+  payload: Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary
- add a Sheets API client plus SWR hooks for masters, orders, and storage aggregation
- wire the prototype page to optionally consume remote data with optimistic updates while preserving the local demo flow
- introduce feature flag and sample env files for configuring the Sheets Apps Script backend

## Testing
- `npm run build`

## How to enable
Set `NEXT_PUBLIC_USE_SHEETS=1` and configure `NEXT_PUBLIC_SHEETS_API_BASE_URL`, `NEXT_PUBLIC_SHEETS_API_KEY` in the environment (e.g. Vercel Project Settings) to enable the remote Sheets mode.

## Rollback
Set `NEXT_PUBLIC_USE_SHEETS` back to `0` to fall back to the in-memory demo data.


------
https://chatgpt.com/codex/tasks/task_b_68ca5c837130832991b5ce734c883401