### PR TITLE
Wire UI to GAS (masters/orders/actions)

### DIFF
--- a/src/app/(ui)/prototype/page.tsx
+++ b/src/app/(ui)/prototype/page.tsx
@@ -12,8 +12,12 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 import { Plus, Package, Warehouse, Archive, Beaker, Factory, Trash2, Boxes, ChefHat } from "lucide-react";
 import { format } from "date-fns";
-import { useMasters, useOrders, useStorageAgg, postAction } from '@/lib/sheets/hooks';
-import type { Masters, OrderRow, StorageAggRow } from '@/lib/sheets/types';
+import { useSWRConfig } from "swr";
+import { useMasters } from "@/hooks/useMasters";
+import { useOrders } from "@/hooks/useOrders";
+import { useStorageAgg } from "@/hooks/useStorageAgg";
+import { apiPost } from "@/lib/gas";
+import type { Masters, OrderRow, StorageAggRow } from "@/lib/sheets/types";
 
 const USE_REMOTE = process.env.NEXT_PUBLIC_USE_SHEETS === '1';
 
@@ -139,66 +143,290 @@ export default function App(){
     <footer className="text-xs text-center text-muted-foreground opacity-70">MVPプロトタイプ・ローカル状態のみ</footer></div>);
 }
 
-function Office({orders,setOrders,seq,setSeq,factories,flavors,oemList,findFlavor}:{orders:OrderCard[];setOrders:React.Dispatch<React.SetStateAction<OrderCard[]>>;seq:number;setSeq:React.Dispatch<React.SetStateAction<number>>;factories:{code:string;name:string}[];flavors:FlavorWithRecipe[];oemList:string[];findFlavor:(id:string)=>FlavorWithRecipe;}){
-  const [factory,setFactory]=useState(factories[0]?.code ?? ""); const [flavor,setFlavor]=useState(flavors[0]?.id ?? ""); const [useType,setUseType]=useState<'fissule'|'oem'>('fissule'); const [packs,setPacks]=useState(100); const [oemPartner,setOemPartner]=useState(oemList[0] ?? ""); const [oemGrams,setOemGrams]=useState(0);
+function Office({
+  orders,
+  setOrders,
+  seq,
+  setSeq,
+  factories,
+  flavors,
+  oemList,
+  findFlavor,
+}: {
+  orders: OrderCard[];
+  setOrders: React.Dispatch<React.SetStateAction<OrderCard[]>>;
+  seq: number;
+  setSeq: React.Dispatch<React.SetStateAction<number>>;
+  factories: { code: string; name: string }[];
+  flavors: FlavorWithRecipe[];
+  oemList: string[];
+  findFlavor: (id: string) => FlavorWithRecipe;
+}) {
+  const { mutate: globalMutate } = useSWRConfig();
+  const [factory, setFactory] = useState(factories[0]?.code ?? "");
+  const [flavor, setFlavor] = useState(flavors[0]?.id ?? "");
+  const [useType, setUseType] = useState<'fissule' | 'oem'>('fissule');
+  const [packs, setPacks] = useState(100);
+  const [oemPartner, setOemPartner] = useState(oemList[0] ?? "");
+  const [oemGrams, setOemGrams] = useState(0);
 
-  useEffect(()=>{ if(factories.length && !factories.some(f=>f.code===factory)){ setFactory(factories[0].code);} },[factories,factory]);
-  useEffect(()=>{ if(flavors.length && !flavors.some(f=>f.id===flavor)){ setFlavor(flavors[0].id);} },[flavors,flavor]);
-  useEffect(()=>{ if(oemList.length && !oemList.includes(oemPartner)){ setOemPartner(oemList[0]);} },[oemList,oemPartner]);
-
-  const buildLine=useCallback((flavorId:string,useType:'fissule'|'oem',packs:number,oemPartner?:string,oemG?:number):OrderLine=>{
-    if(useType==='fissule'){
-      const flavorInfo=findFlavor(flavorId);
-      return {flavorId,packs,requiredGrams:packs*(flavorInfo?.packToGram ?? 0),useType};
+  useEffect(() => {
+    if (factories.length && !factories.some(f => f.code === factory)) {
+      setFactory(factories[0].code);
     }
-    const gramsVal=Math.max(0,oemG||0);
-    return {flavorId,packs:0,requiredGrams:gramsVal,useType,oemPartner,oemGrams:gramsVal};
-  },[findFlavor]);
+  }, [factories, factory]);
 
-  const createOrder=()=>{
-    if(!factory||!flavor) return;
-    const today=new Date();
-    const lot=genLotId(factory,seq,today);
-    const line=buildLine(flavor,useType,packs,oemPartner,oemGrams);
-    if((useType==='fissule'&&packs<=0)||(useType==='oem'&&(!oemPartner||(oemGrams||0)<=0)))return;
-    const newOrder:OrderCard={orderId:`O-${String(seq).padStart(3,"0")}`,lotId:lot,factoryCode:factory,orderedAt:format(today,"yyyy-MM-dd"),lines:[line]};
-    setOrders(prev=>[newOrder,...prev]);
-    setSeq(n=>n+1);
-  };
+  useEffect(() => {
+    if (flavors.length && !flavors.some(f => f.id === flavor)) {
+      setFlavor(flavors[0].id);
+    }
+  }, [flavors, flavor]);
 
-  return (<div className="grid md:grid-cols-2 gap-6">
-    <Card className="shadow-sm"><CardHeader><CardTitle className="flex items-center gap-2"><Plus className="h-5 w-5"/>製造指示チケットの作成</CardTitle></CardHeader><CardContent className="space-y-4">
-      <div><Label>製造場所</Label><Select value={factory} onValueChange={setFactory}><SelectTrigger><SelectValue placeholder="選択"/></SelectTrigger><SelectContent>{factories.map(f=> <SelectItem key={f.code} value={f.code}>{f.name}（{f.code}）</SelectItem>)}</SelectContent></Select></div>
-      {useType==='fissule'? (<div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
-        <div><Label>味付け</Label><Select value={flavor} onValueChange={setFlavor}><SelectTrigger><SelectValue/></SelectTrigger><SelectContent>{flavors.map(fl=> <SelectItem key={fl.id} value={fl.id}>{fl.flavorName}</SelectItem>)}</SelectContent></Select></div>
-        <div><Label>用途</Label><Select value={useType} onValueChange={(value: 'fissule' | 'oem') => setUseType(value)}><SelectTrigger><SelectValue/></SelectTrigger><SelectContent><SelectItem value="fissule">製品（パック）</SelectItem><SelectItem value="oem">OEM</SelectItem></SelectContent></Select></div>
-        <div><Label>パック数</Label><Input type="number" value={packs} onChange={e=>setPacks(parseInt(e.target.value||"0"))}/><div className="text-xs text-muted-foreground mt-1">必要量: {grams(packs*(findFlavor(flavor)?.packToGram ?? 0))}</div></div>
-      </div>) : (
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
-          <div><Label>味付け</Label><Select value={flavor} onValueChange={setFlavor}><SelectTrigger><SelectValue/></SelectTrigger><SelectContent>{flavors.map(fl=> <SelectItem key={fl.id} value={fl.id}>{fl.flavorName}</SelectItem>)}</SelectContent></Select></div>
-          <div><Label>用途</Label><Select value={useType} onValueChange={(value: 'fissule' | 'oem') => setUseType(value)}><SelectTrigger><SelectValue/></SelectTrigger><SelectContent><SelectItem value="fissule">製品（パック）</SelectItem><SelectItem value="oem">OEM</SelectItem></SelectContent></Select></div>
-          <div><Label>OEM先</Label><Select value={oemPartner} onValueChange={setOemPartner}><SelectTrigger><SelectValue/></SelectTrigger><SelectContent>{oemList.map(x=> <SelectItem key={x} value={x}>{x}</SelectItem>)}</SelectContent></Select></div>
-          <div className="md:col-span-3"><Label>作成グラム数（g）</Label><Input type="number" value={oemGrams} onChange={e=>setOemGrams(parseInt(e.target.value||"0"))}/></div>
-        </div>) }
-      <div className="flex gap-3"><Button onClick={createOrder}>チケットを登録</Button><div className="text-sm text-muted-foreground flex items-center gap-2"><Beaker className="h-4 w-4"/><span>パック→g は味付け設定で自動換算</span></div></div>
-    </CardContent></Card>
+  useEffect(() => {
+    if (oemList.length && !oemList.includes(oemPartner)) {
+      setOemPartner(oemList[0]);
+    }
+  }, [oemList, oemPartner]);
 
-    <Card className="shadow-sm"><CardHeader><CardTitle className="flex items-center gap-2"><Package className="h-5 w-5"/>進捗（未アーカイブ）</CardTitle></CardHeader>
-      <CardContent className="space-y-3 max-h-[540px] overflow-auto pr-2">
-        {orders.filter(o=>!o.archived).map(order=> (
-          <div key={order.orderId} className="border rounded-xl p-3 space-y-2">
-            <div className="flex flex-wrap items-center justify-between gap-2"><div className="font-medium">{order.lotId} <Badge variant="secondary" className="ml-2">{factories.find(f=>f.code===order.factoryCode)?.name || order.factoryCode}</Badge></div><div className="text-xs opacity-70">指示日 {order.orderedAt}</div></div>
-            {order.lines.map((ln,i)=>{const f=findFlavor(ln.flavorId);return (
-              <div key={i} className="text-sm grid gap-3">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4"><Field label="味付け">{f.flavorName}</Field><Field label="用途">{ln.useType==='oem'? 'OEM':'製品'}</Field></div>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4"><Field label={ln.useType==='fissule'? 'パック数':'OEM先'}>{ln.useType==='fissule'? ln.packs: ln.oemPartner}</Field><Field label="必要量"><span className="font-semibold">{grams(ln.requiredGrams)}</span></Field></div>
-              </div> );})}
-          </div>))}
-        {orders.filter(o=>!o.archived).length===0 && <div className="text-sm text-muted-foreground">未処理の指示はありません</div>}
-      </CardContent>
-      <CardFooter className="justify-end"><Badge variant="outline" className="gap-1"><Archive className="h-3 w-3"/> アーカイブは現場側から</Badge></CardFooter>
-    </Card>
-  </div>);
+  const buildLine = useCallback(
+    (flavorId: string, lineUseType: 'fissule' | 'oem', packCount: number, partner?: string, oemG?: number): OrderLine => {
+      if (lineUseType === 'fissule') {
+        const flavorInfo = findFlavor(flavorId);
+        return {
+          flavorId,
+          packs: packCount,
+          requiredGrams: packCount * (flavorInfo?.packToGram ?? 0),
+          useType: lineUseType,
+        };
+      }
+      const gramsVal = Math.max(0, oemG || 0);
+      return {
+        flavorId,
+        packs: 0,
+        requiredGrams: gramsVal,
+        useType: lineUseType,
+        oemPartner: partner,
+        oemGrams: gramsVal,
+      };
+    },
+    [findFlavor],
+  );
+
+  const createOrder = useCallback(async () => {
+    if (!factory || !flavor) return;
+    const today = new Date();
+    const lot = genLotId(factory, seq, today);
+    const line = buildLine(flavor, useType, packs, oemPartner, oemGrams);
+    if ((useType === 'fissule' && packs <= 0) || (useType === 'oem' && (!oemPartner || (oemGrams || 0) <= 0))) return;
+    const newOrder: OrderCard = {
+      orderId: `O-${String(seq).padStart(3, "0")}`,
+      lotId: lot,
+      factoryCode: factory,
+      orderedAt: format(today, "yyyy-MM-dd"),
+      lines: [line],
+    };
+    setOrders(prev => [newOrder, ...prev]);
+    setSeq(n => n + 1);
+
+    if (USE_REMOTE) {
+      try {
+        await apiPost("orders-create", {
+          order_id: newOrder.orderId,
+          factory_code: factory,
+          lot_id: lot,
+          ordered_at: newOrder.orderedAt,
+          lines: [
+            {
+              flavor_id: line.flavorId,
+              use_type: line.useType,
+              packs: line.packs,
+              required_grams: line.requiredGrams,
+              oem_partner: line.oemPartner,
+              oem_grams: line.oemGrams,
+            },
+          ],
+        });
+        await globalMutate(["orders", factory, false]);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+  }, [factory, flavor, seq, buildLine, useType, packs, oemPartner, oemGrams, setOrders, setSeq, globalMutate]);
+
+  return (
+    <div className="grid md:grid-cols-2 gap-6">
+      <Card className="shadow-sm">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Plus className="h-5 w-5" />製造指示チケットの作成
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <Label>製造場所</Label>
+            <Select value={factory} onValueChange={setFactory}>
+              <SelectTrigger>
+                <SelectValue placeholder="選択" />
+              </SelectTrigger>
+              <SelectContent>
+                {factories.map(f => (
+                  <SelectItem key={f.code} value={f.code}>
+                    {f.name}（{f.code}）
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          {useType === 'fissule' ? (
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
+              <div>
+                <Label>味付け</Label>
+                <Select value={flavor} onValueChange={setFlavor}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {flavors.map(fl => (
+                      <SelectItem key={fl.id} value={fl.id}>
+                        {fl.flavorName}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label>用途</Label>
+                <Select value={useType} onValueChange={(value: 'fissule' | 'oem') => setUseType(value)}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="fissule">製品（パック）</SelectItem>
+                    <SelectItem value="oem">OEM</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label>パック数</Label>
+                <Input type="number" value={packs} onChange={e => setPacks(parseInt(e.target.value || "0", 10))} />
+                <div className="text-xs text-muted-foreground mt-1">
+                  必要量: {grams(packs * (findFlavor(flavor)?.packToGram ?? 0))}
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
+              <div>
+                <Label>味付け</Label>
+                <Select value={flavor} onValueChange={setFlavor}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {flavors.map(fl => (
+                      <SelectItem key={fl.id} value={fl.id}>
+                        {fl.flavorName}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label>用途</Label>
+                <Select value={useType} onValueChange={(value: 'fissule' | 'oem') => setUseType(value)}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="fissule">製品（パック）</SelectItem>
+                    <SelectItem value="oem">OEM</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label>OEM先</Label>
+                <Select value={oemPartner} onValueChange={setOemPartner}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {oemList.map(x => (
+                      <SelectItem key={x} value={x}>
+                        {x}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="md:col-span-3">
+                <Label>作成グラム数（g）</Label>
+                <Input type="number" value={oemGrams} onChange={e => setOemGrams(parseInt(e.target.value || "0", 10))} />
+              </div>
+            </div>
+          )}
+          <div className="flex gap-3">
+            <Button onClick={() => { void createOrder(); }}>チケットを登録</Button>
+            <div className="text-sm text-muted-foreground flex items-center gap-2">
+              <Beaker className="h-4 w-4" />
+              <span>パック→g は味付け設定で自動換算</span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="shadow-sm">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Package className="h-5 w-5" />進捗（未アーカイブ）
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 max-h-[540px] overflow-auto pr-2">
+          {orders
+            .filter(o => !o.archived)
+            .map(order => (
+              <div key={order.orderId} className="border rounded-xl p-3 space-y-2">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="font-medium">
+                    {order.lotId}{" "}
+                    <Badge variant="secondary" className="ml-2">
+                      {factories.find(f => f.code === order.factoryCode)?.name || order.factoryCode}
+                    </Badge>
+                  </div>
+                  <div className="text-xs opacity-70">指示日 {order.orderedAt}</div>
+                </div>
+                {order.lines.map((ln, i) => {
+                  const f = findFlavor(ln.flavorId);
+                  return (
+                    <div key={i} className="text-sm grid gap-3">
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <Field label="味付け">{f.flavorName}</Field>
+                        <Field label="用途">{ln.useType === 'oem' ? 'OEM' : '製品'}</Field>
+                      </div>
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <Field label={ln.useType === 'fissule' ? 'パック数' : 'OEM先'}>
+                          {ln.useType === 'fissule' ? ln.packs : ln.oemPartner}
+                        </Field>
+                        <Field label="必要量">
+                          <span className="font-semibold">{grams(ln.requiredGrams)}</span>
+                        </Field>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ))}
+          {orders.filter(o => !o.archived).length === 0 && (
+            <div className="text-sm text-muted-foreground">未処理の指示はありません</div>
+          )}
+        </CardContent>
+        <CardFooter className="justify-end">
+          <Badge variant="outline" className="gap-1">
+            <Archive className="h-3 w-3" /> アーカイブは現場側から
+          </Badge>
+        </CardFooter>
+      </Card>
+    </div>
+  );
 }
 
 function Floor({orders,setOrders,storage,setStorage,registerOnsiteMake,splitLogs,setSplitLogs,factories,flavors,findFlavor,storageByFactory,oemList,calcExpiry}:{orders:OrderCard[];setOrders:React.Dispatch<React.SetStateAction<OrderCard[]>>;storage:StorageEntry[];setStorage:React.Dispatch<React.SetStateAction<StorageEntry[]>>;registerOnsiteMake:(factoryCode:string,flavorId:string,useType:'fissule'|'oem',producedG:number,manufacturedAt:string,oemPartner?:string,leftover?:{loc:string;grams:number})=>void;splitLogs:SplitLog[];setSplitLogs:React.Dispatch<React.SetStateAction<SplitLog[]>>;factories:{code:string;name:string}[];flavors:FlavorWithRecipe[];findFlavor:(id:string)=>FlavorWithRecipe;storageByFactory:Record<string,string[]>;oemList:string[];calcExpiry:(manufacturedAt:string,flavorId:string)=>string;}){
@@ -207,9 +435,11 @@ function Floor({orders,setOrders,storage,setStorage,registerOnsiteMake,splitLogs
   useEffect(()=>{ if(!factories.length){ setFactory(""); return;} if(!factory || !factories.some(f=>f.code===factory)){ setFactory(factories[0].code);} },[factories,factory]);
 
   const ordersQuery = useOrders(USE_REMOTE ? (factory || undefined) : undefined);
+  const { data: ordersData, mutate: mutateOrders } = ordersQuery;
   const storageAggQuery = useStorageAgg(USE_REMOTE ? (factory || undefined) : undefined);
+  const { data: storageAggData, mutate: mutateStorageAgg } = storageAggQuery;
 
-  const remoteOrders = USE_REMOTE ? ordersQuery?.data : undefined;
+  const remoteOrders = USE_REMOTE ? ordersData : undefined;
   useEffect(()=>{
     if(!USE_REMOTE || !remoteOrders) return;
     const cardMap=new Map<string,OrderCard>();
@@ -228,7 +458,19 @@ function Floor({orders,setOrders,storage,setStorage,registerOnsiteMake,splitLogs
     setOrders(Array.from(cardMap.values()));
   },[remoteOrders,setOrders]);
 
-  const remoteStorageAgg = USE_REMOTE ? storageAggQuery?.data : undefined;
+  const remoteStorageAgg = USE_REMOTE ? storageAggData : undefined;
+
+  const refreshOrders = useCallback(async () => {
+    if (USE_REMOTE) {
+      await mutateOrders();
+    }
+  }, [mutateOrders]);
+
+  const refreshStorageAgg = useCallback(async () => {
+    if (USE_REMOTE) {
+      await mutateStorageAgg();
+    }
+  }, [mutateStorageAgg]);
 
   const openOrders=useMemo(()=>orders.filter(o=>!o.archived&&o.factoryCode===factory),[orders,factory]);
   const storageAgg=useMemo(()=>{
@@ -253,7 +495,7 @@ function Floor({orders,setOrders,storage,setStorage,registerOnsiteMake,splitLogs
 
   const producedPacksByLot=useCallback((lotId:string)=> splitLogs.filter(l=>l.lotId===lotId).reduce((a,b)=>a+b.packs,0),[splitLogs]);
 
-  const addSplit=useCallback((order:OrderCard,packs:number,manufacturedAt:string)=>{
+  const addSplit=useCallback(async (order:OrderCard,packs:number,manufacturedAt:string)=>{
     const ln=order.lines[0];
     const subNo=splitLogs.filter(l=>l.lotId===order.lotId).length+1;
     const gramsMade=packs*(findFlavor(ln.flavorId)?.packToGram ?? 0);
@@ -261,23 +503,46 @@ function Floor({orders,setOrders,storage,setStorage,registerOnsiteMake,splitLogs
     const total=producedPacksByLot(order.lotId)+packs;
     if(ln.packs>0 && total>=ln.packs){ setOrders(os=> os.map(o=> o.orderId===order.orderId?{...o,archived:true}:o)); }
     if(USE_REMOTE){
-      void postAction({ path:'action', type:'MADE_SPLIT', factory_code:order.factoryCode, lot_id:order.lotId, flavor_id:ln.flavorId, payload:{ packs, grams:gramsMade, manufactured_at:manufacturedAt, sub_no:subNo } }).catch(err=>console.error(err));
+      try {
+        await apiPost("action", { type:"MADE_SPLIT", factory_code:order.factoryCode, lot_id:order.lotId, flavor_id:ln.flavorId, payload:{ packs, grams:gramsMade, manufactured_at:manufacturedAt, sub_no:subNo } });
+        await Promise.all([refreshOrders(), refreshStorageAgg()]);
+      } catch (err) {
+        console.error(err);
+      }
     }
-  },[findFlavor,producedPacksByLot,setOrders,setSplitLogs,splitLogs]);
+  },[findFlavor,producedPacksByLot,refreshOrders,refreshStorageAgg,setOrders,setSplitLogs,splitLogs]);
 
   return (<div className="grid md:grid-cols-2 gap-6 items-start">
     <div className="flex items-center gap-3"><Label>製造場所</Label><Select value={factory} onValueChange={setFactory}><SelectTrigger className="w-56"><SelectValue/></SelectTrigger><SelectContent>{factories.map(f=> <SelectItem key={f.code} value={f.code}>{f.name}（{f.code}）</SelectItem>)}</SelectContent></Select></div>
     <div className="md:col-span-2 grid md:grid-cols-2 gap-6">
       <KanbanColumn title="製造指示" icon={<ChefHat className="h-4 w-4"/>} rightSlot={<Button variant="outline" onClick={()=>setExtraOpen(true)} className="gap-1"><Plus className="h-4 w-4"/>追加で作成</Button>}>
-        {openOrders.map(o=> <OrderCardView key={o.orderId} order={o} onArchive={()=>setOrders(prev=>prev.map(od=>od.orderId===o.orderId?{...od,archived:true}:od))} onAddStorage={entries=>setStorage(prev=>[...prev,...entries])} remainingPacks={Math.max(0,(o.lines[0].packs||0)-producedPacksByLot(o.lotId))} splitLogs={splitLogs.filter(s=>s.lotId===o.lotId)} onAddSplit={addSplit} findFlavor={findFlavor} storageByFactory={storageByFactory}/> ) }
+        {openOrders.map(o=> <OrderCardView key={o.orderId} order={o} onArchive={()=>setOrders(prev=>prev.map(od=>od.orderId===o.orderId?{...od,archived:true}:od))} onAddStorage={entries=>setStorage(prev=>[...prev,...entries])} remainingPacks={Math.max(0,(o.lines[0].packs||0)-producedPacksByLot(o.lotId))} splitLogs={splitLogs.filter(s=>s.lotId===o.lotId)} onAddSplit={addSplit} findFlavor={findFlavor} storageByFactory={storageByFactory} onRemoteStorageRefresh={refreshStorageAgg}/> ) }
         {openOrders.length===0 && <Empty>ここにカードが表示されます</Empty>}
       </KanbanColumn>
       <KanbanColumn title="保管（在庫）" icon={<Warehouse className="h-4 w-4"/>}>
-        {storageAgg.map(sa=> <StorageCardView key={sa.lotId} agg={sa} onUse={(qty,leftoverQty,location)=>{setStorage(prev=>{const next=[...prev,{lotId:sa.lotId,factoryCode:factory,flavorId:sa.flavorId,location,grams:-qty,manufacturedAt:sa.manufacturedAt}]; if(leftoverQty>0){ next.push({lotId:sa.lotId,factoryCode:factory,flavorId:sa.flavorId,location,grams:leftoverQty,manufacturedAt:sa.manufacturedAt}); } return next;});}} onWaste={(qty,reason,location)=>{if(typeof qty==='number'){setStorage(prev=>[...prev,{lotId:sa.lotId,factoryCode:factory,flavorId:sa.flavorId,location,grams:-Math.abs(qty),manufacturedAt:sa.manufacturedAt}]);}}} findFlavor={findFlavor} calcExpiry={calcExpiry} factoryCode={factory}/>) }
+        {storageAgg.map(sa=> <StorageCardView key={sa.lotId} agg={sa} onUse={(qty,leftoverQty,location)=>{setStorage(prev=>{const next=[...prev,{lotId:sa.lotId,factoryCode:factory,flavorId:sa.flavorId,location,grams:-qty,manufacturedAt:sa.manufacturedAt}]; if(leftoverQty>0){ next.push({lotId:sa.lotId,factoryCode:factory,flavorId:sa.flavorId,location,grams:leftoverQty,manufacturedAt:sa.manufacturedAt}); } return next;});}} onWaste={(qty,reason,location)=>{if(typeof qty==='number'){setStorage(prev=>[...prev,{lotId:sa.lotId,factoryCode:factory,flavorId:sa.flavorId,location,grams:-Math.abs(qty),manufacturedAt:sa.manufacturedAt}]);}}} findFlavor={findFlavor} calcExpiry={calcExpiry} factoryCode={factory} onRemoteStorageRefresh={refreshStorageAgg}/>) }
         {storageAgg.length===0 && <Empty>余剰の在庫はここに集計されます</Empty>}
       </KanbanColumn>
     </div>
-    <OnsiteMakeDialog open={extraOpen} onClose={()=>setExtraOpen(false)} defaultFlavorId={flavors[0]?.id ?? ""} factoryCode={factory} onRegister={registerOnsiteMake} flavors={flavors} oemList={oemList} findFlavor={findFlavor} storageByFactory={storageByFactory}/>
+    <OnsiteMakeDialog open={extraOpen} onClose={()=>setExtraOpen(false)} defaultFlavorId={flavors[0]?.id ?? ""} factoryCode={factory} onRegister={async (factoryCode,flavorId,useType,producedG,manufacturedAt,oemPartner,leftover)=>{
+      registerOnsiteMake(factoryCode,flavorId,useType,producedG,manufacturedAt,oemPartner,leftover);
+      if(USE_REMOTE){
+        try {
+          await apiPost("onsite-make", {
+            factory_code: factoryCode,
+            flavor_id: flavorId,
+            use_type: useType,
+            produced_grams: producedG,
+            manufactured_at: manufacturedAt,
+            oem_partner: oemPartner,
+            leftover: leftover ? { location: leftover.loc, grams: leftover.grams } : undefined,
+          });
+          await Promise.all([refreshOrders(), refreshStorageAgg()]);
+        } catch (err) {
+          console.error(err);
+        }
+      }
+    }} flavors={flavors} oemList={oemList} findFlavor={findFlavor} storageByFactory={storageByFactory}/>
   </div>);
 }
 
@@ -286,7 +551,7 @@ function KanbanColumn({title,icon,rightSlot,children}:{title:string;icon?:React.
 }
 const Empty=({children}:{children:React.ReactNode})=> (<div className="text-sm text-muted-foreground border rounded-xl p-6 text-center">{children}</div>);
 
-function OrderCardView({order,onArchive,onAddStorage,remainingPacks,splitLogs,onAddSplit,findFlavor,storageByFactory}:{order:OrderCard;onArchive:()=>void;onAddStorage:(e:StorageEntry[])=>void;remainingPacks:number;splitLogs:SplitLog[];onAddSplit:(order:OrderCard,packs:number,manufacturedAt:string)=>void;findFlavor:(id:string)=>FlavorWithRecipe;storageByFactory:Record<string,string[]>;}){
+function OrderCardView({order,onArchive,onAddStorage,remainingPacks,splitLogs,onAddSplit,findFlavor,storageByFactory,onRemoteStorageRefresh}:{order:OrderCard;onArchive:()=>void;onAddStorage:(e:StorageEntry[])=>void;remainingPacks:number;splitLogs:SplitLog[];onAddSplit:(order:OrderCard,packs:number,manufacturedAt:string)=>Promise<void>|void;findFlavor:(id:string)=>FlavorWithRecipe;storageByFactory:Record<string,string[]>;onRemoteStorageRefresh?:()=>Promise<void>;}){
   const [open,setOpen]=useState<null|"keep"|"made"|"skip"|"choice"|"split">(null); const ln=order.lines[0]; const flavor=findFlavor(ln.flavorId); const reset=()=>setOpen(null);
   const canSplit = ln.useType==='fissule' && ln.packs>0;
   return (<Card className="border rounded-xl"><CardContent className="pt-4 space-y-3">
@@ -298,10 +563,10 @@ function OrderCardView({order,onArchive,onAddStorage,remainingPacks,splitLogs,on
     </div>
     <div className="flex flex-wrap gap-2"><Button variant="outline" onClick={()=>setOpen("keep")}>保管</Button><Button onClick={()=> setOpen("choice")}>作った</Button><Button variant="secondary" onClick={()=>setOpen("skip")}>作らない</Button></div>
   </CardContent>
-  <KeepDialog open={open==="keep"} onClose={reset} factoryCode={order.factoryCode} flavorId={ln.flavorId} lotId={order.lotId} storageByFactory={storageByFactory} onSubmit={async (loc,g,mfg)=>{onAddStorage([{lotId:order.lotId,factoryCode:order.factoryCode,location:loc,grams:g,flavorId:ln.flavorId,manufacturedAt:mfg}]);onArchive();}}/>
-  <MadeDialog2 open={open==="made"} mode="bulk" onClose={reset} order={order} remaining={remainingPacks} onAddStorage={onAddStorage} onAddSplit={(packs,date)=>{onAddSplit(order,packs,date);}} findFlavor={findFlavor} storageByFactory={storageByFactory}/>
+  <KeepDialog open={open==="keep"} onClose={reset} factoryCode={order.factoryCode} flavorId={ln.flavorId} lotId={order.lotId} storageByFactory={storageByFactory} onSubmit={async (loc,g,mfg)=>{onAddStorage([{lotId:order.lotId,factoryCode:order.factoryCode,location:loc,grams:g,flavorId:ln.flavorId,manufacturedAt:mfg}]);onArchive();}} onRemoteStorageRefresh={onRemoteStorageRefresh}/>
+  <MadeDialog2 open={open==="made"} mode="bulk" onClose={reset} order={order} remaining={remainingPacks} onAddStorage={onAddStorage} onAddSplit={(packs,date)=>{void onAddSplit(order,packs,date);}} findFlavor={findFlavor} storageByFactory={storageByFactory}/>
   <MadeChoiceDialog open={open==="choice"} onClose={reset} canSplit={canSplit} onBulk={()=>setOpen("made")} onSplit={()=>setOpen("split")}/>
-  <MadeDialog2 open={open==="split"} mode="split" onClose={reset} order={order} remaining={remainingPacks} onAddStorage={onAddStorage} onAddSplit={(packs,date)=>{onAddSplit(order,packs,date);}} findFlavor={findFlavor} storageByFactory={storageByFactory}/>
+  <MadeDialog2 open={open==="split"} mode="split" onClose={reset} order={order} remaining={remainingPacks} onAddStorage={onAddStorage} onAddSplit={(packs,date)=>{void onAddSplit(order,packs,date);}} findFlavor={findFlavor} storageByFactory={storageByFactory}/>
   <Dialog open={open==="skip"} onOpenChange={(o)=>{if(!o)reset();}}><DialogContent><DialogHeader><DialogTitle>作らない理由（任意）</DialogTitle></DialogHeader></DialogContent></Dialog>
   </Card>);
 }
@@ -313,7 +578,7 @@ function MadeChoiceDialog({open,onClose,canSplit,onBulk,onSplit}:{open:boolean;o
   </DialogContent></Dialog>);
 }
 
-function KeepDialog({open,onClose,factoryCode,flavorId,lotId,storageByFactory,onSubmit}:{open:boolean;onClose:()=>void;factoryCode:string;flavorId:string;lotId:string;storageByFactory:Record<string,string[]>;onSubmit:(location:string,grams:number,manufacturedAt:string)=>Promise<void>|void;}){
+function KeepDialog({open,onClose,factoryCode,flavorId,lotId,storageByFactory,onSubmit,onRemoteStorageRefresh}:{open:boolean;onClose:()=>void;factoryCode:string;flavorId:string;lotId:string;storageByFactory:Record<string,string[]>;onSubmit:(location:string,grams:number,manufacturedAt:string)=>Promise<void>|void;onRemoteStorageRefresh?:()=>Promise<void>;}){
   const [loc,setLoc]=useState(""); const [g,setG]=useState(0); const [mfg,setMfg]=useState(format(new Date(),"yyyy-MM-dd")); const locs=storageByFactory[factoryCode]||[];
   useEffect(()=>{ if(open){ setLoc(""); setG(0); setMfg(format(new Date(),"yyyy-MM-dd")); } },[open]);
   const handleSubmit=async()=>{
@@ -321,7 +586,8 @@ function KeepDialog({open,onClose,factoryCode,flavorId,lotId,storageByFactory,on
     await onSubmit(loc,g,mfg);
     if(USE_REMOTE){
       try {
-        await postAction({ path:'action', type:'KEEP', factory_code:factoryCode, lot_id:lotId, flavor_id:flavorId, payload:{ location:loc, grams:g, manufactured_at:mfg } });
+        await apiPost("action", { type:"KEEP", factory_code:factoryCode, lot_id:lotId, flavor_id:flavorId, payload:{ location:loc, grams:g, manufactured_at:mfg } });
+        if(onRemoteStorageRefresh){ await onRemoteStorageRefresh(); }
       } catch (err) {
         console.error(err);
       }
@@ -426,22 +692,29 @@ function MadeDialog2({open,onClose,order,mode,remaining,onAddStorage,onAddSplit,
   );
 }
 
-function OnsiteMakeDialog({open,onClose,defaultFlavorId,factoryCode,onRegister,flavors,oemList,findFlavor,storageByFactory}:{open:boolean;onClose:()=>void;defaultFlavorId:string;factoryCode:string;onRegister:(factoryCode:string,flavorId:string,useType:'fissule'|'oem',producedG:number,manufacturedAt:string,oemPartner?:string,leftover?:{loc:string;grams:number})=>void;flavors:FlavorWithRecipe[];oemList:string[];findFlavor:(id:string)=>FlavorWithRecipe;storageByFactory:Record<string,string[]>;}){
+function OnsiteMakeDialog({open,onClose,defaultFlavorId,factoryCode,onRegister,flavors,oemList,findFlavor,storageByFactory}:{open:boolean;onClose:()=>void;defaultFlavorId:string;factoryCode:string;onRegister:(factoryCode:string,flavorId:string,useType:'fissule'|'oem',producedG:number,manufacturedAt:string,oemPartner?:string,leftover?:{loc:string;grams:number})=>Promise<void>|void;flavors:FlavorWithRecipe[];oemList:string[];findFlavor:(id:string)=>FlavorWithRecipe;storageByFactory:Record<string,string[]>;}){
   const [flavorId,setFlavorId]=useState(defaultFlavorId); const f=findFlavor(flavorId); const [mfg,setMfg]=useState(format(new Date(),"yyyy-MM-dd")); const [useType,setUseType]=useState<'fissule'|'oem'>('fissule'); const [oemPartner,setOemPartner]=useState(oemList[0] ?? ""); const [checked,setChecked]=useState<Record<string,boolean>>({}); const [qty,setQty]=useState<Record<string,number>>({}); const [outcome,setOutcome]=useState<'extra'|'used'|''>(''); const [leftLoc,setLeftLoc]=useState(""); const [leftG,setLeftG]=useState(0);
   const sum=Object.keys(qty).reduce((acc,k)=>acc+(checked[k]?(qty[k]||0):0),0);
   useEffect(()=>{setChecked({});setQty({});},[flavorId]);
   useEffect(()=>{if(open){setFlavorId(defaultFlavorId); setUseType('fissule'); setOemPartner(oemList[0] ?? ""); setOutcome(''); setLeftLoc(''); setLeftG(0); setMfg(format(new Date(),"yyyy-MM-dd"));}},[open,defaultFlavorId,oemList]);
-  const submit=()=>{onRegister(factoryCode,flavorId,useType,sum,mfg,useType==='oem'?oemPartner:undefined,outcome==='extra'?{loc:leftLoc,grams:leftG}:undefined);onClose();};
+  const submit=async()=>{
+    try {
+      await onRegister(factoryCode,flavorId,useType,sum,mfg,useType==='oem'?oemPartner:undefined,outcome==='extra'?{loc:leftLoc,grams:leftG}:undefined);
+      onClose();
+    } catch (err) {
+      console.error(err);
+    }
+  };
   return (<Dialog open={open} onOpenChange={(o)=>{if(!o)onClose();}}><DialogContent className="max-w-2xl"><DialogHeader><DialogTitle>追加で作成（現場報告）</DialogTitle></DialogHeader>
     <div className="grid md:grid-cols-3 gap-3"><div className="md:col-span-1"><Label>レシピ</Label><Select value={flavorId} onValueChange={setFlavorId}><SelectTrigger><SelectValue/></SelectTrigger><SelectContent>{flavors.map(fl=> <SelectItem key={fl.id} value={fl.id}>{fl.flavorName}</SelectItem>)}</SelectContent></Select></div><div><Label>用途</Label><Select value={useType} onValueChange={(value: 'fissule' | 'oem') => setUseType(value)}><SelectTrigger><SelectValue/></SelectTrigger><SelectContent><SelectItem value="fissule">製品</SelectItem><SelectItem value="oem">OEM</SelectItem></SelectContent></Select></div><div><Label>製造日</Label><Input type="date" value={mfg} onChange={(e)=>setMfg(e.target.value)}/></div></div>
     {useType==='oem' && (<div><Label>OEM先</Label><Select value={oemPartner} onValueChange={setOemPartner}><SelectTrigger><SelectValue/></SelectTrigger><SelectContent>{oemList.map(x=> <SelectItem key={x} value={x}>{x}</SelectItem>)}</SelectContent></Select></div>)}
     <div className="rounded-xl border p-3 space-y-3"><div className="text-sm font-medium">レシピ：{f.liquidName}</div>{f.recipe.map((r,idx)=> (<div key={idx} className="flex items-center justify-between gap-3"><div className="flex items-center gap-2"><Checkbox id={`ing2-${idx}`} checked={!!checked[r.ingredient]} onCheckedChange={(v)=>setChecked({...checked,[r.ingredient]:Boolean(v)})}/><Label htmlFor={`ing2-${idx}`}>{r.ingredient}</Label></div><div className="flex items-center gap-2"><Input className="w-28" type="number" value={qty[r.ingredient]||0} onChange={(e)=>setQty({...qty,[r.ingredient]:parseInt(e.target.value||'0')})}/><span className="text-sm opacity-70">g</span></div></div>))}<div className="text-right text-sm">作成量 合計：<span className="font-semibold">{grams(sum)}</span></div></div>
     <div className="grid md:grid-cols-3 gap-3"><div><Label>結果</Label><Select value={outcome} onValueChange={(value: 'extra' | 'used') => setOutcome(value)}><SelectTrigger><SelectValue placeholder="選択"/></SelectTrigger><SelectContent><SelectItem value="used">使い切った</SelectItem><SelectItem value="extra">余った</SelectItem></SelectContent></Select></div>{outcome==='extra' && (<><div><Label>保管場所</Label><Select value={leftLoc} onValueChange={setLeftLoc}><SelectTrigger><SelectValue placeholder="選択"/></SelectTrigger><SelectContent>{(storageByFactory[factoryCode]||[]).map(l=> <SelectItem key={l} value={l}>{l}</SelectItem>)}</SelectContent></Select></div><div><Label>余り数量（g）</Label><Input type="number" value={leftG} onChange={(e)=>setLeftG(parseInt(e.target.value||'0'))}/></div></>)}</div>
-    <DialogFooter><Button variant="secondary" onClick={onClose}>キャンセル</Button><Button disabled={sum<=0||!mfg||(useType==='oem'&&!oemPartner)||(outcome==='extra'&&(!leftLoc||leftG<=0))} onClick={submit}>登録</Button></DialogFooter>
+    <DialogFooter><Button variant="secondary" onClick={onClose}>キャンセル</Button><Button disabled={sum<=0||!mfg||(useType==='oem'&&!oemPartner)||(outcome==='extra'&&(!leftLoc||leftG<=0))} onClick={()=>{void submit();}}>登録</Button></DialogFooter>
   </DialogContent></Dialog>);
 }
 
-function StorageCardView({agg,onUse,onWaste,findFlavor,calcExpiry,factoryCode}:{agg:{lotId:string;grams:number;locations:Set<string>;flavorId:string;manufacturedAt:string};onUse:(usedQty:number,leftover:number,location:string)=>Promise<void>|void;onWaste:(qtyOrText:number|string,reason:'expiry'|'mistake'|'other',location:string)=>Promise<void>|void;findFlavor:(id:string)=>FlavorWithRecipe;calcExpiry:(manufacturedAt:string,flavorId:string)=>string;factoryCode:string;}){
+function StorageCardView({agg,onUse,onWaste,findFlavor,calcExpiry,factoryCode,onRemoteStorageRefresh}:{agg:{lotId:string;grams:number;locations:Set<string>;flavorId:string;manufacturedAt:string};onUse:(usedQty:number,leftover:number,location:string)=>Promise<void>|void;onWaste:(qtyOrText:number|string,reason:'expiry'|'mistake'|'other',location:string)=>Promise<void>|void;findFlavor:(id:string)=>FlavorWithRecipe;calcExpiry:(manufacturedAt:string,flavorId:string)=>string;factoryCode:string;onRemoteStorageRefresh?:()=>Promise<void>;}){
   const [useOpen,setUseOpen]=useState(false); const [wasteOpen,setWasteOpen]=useState(false);
   const [useQty,setUseQty]=useState(0); const [useOutcome,setUseOutcome]=useState<'extra'|'none'|'shortage'|''>(''); const [leftQty,setLeftQty]=useState(0); const [loc,setLoc]=useState<string>(Array.from(agg.locations)[0]||"");
   const [wasteReason,setWasteReason]=useState<'expiry'|'mistake'|'other'|''>(''); const [wasteQty,setWasteQty]=useState(0); const [wasteText,setWasteText]=useState("");
@@ -454,7 +727,8 @@ function StorageCardView({agg,onUse,onWaste,findFlavor,calcExpiry,factoryCode}:{
     await onUse(useQty,useOutcome==='extra'?leftQty:0,location);
     if(USE_REMOTE){
       try {
-        await postAction({ path:'action', type:'USE', factory_code:factoryCode, lot_id:agg.lotId, flavor_id:agg.flavorId, payload:{ qty:useQty, location } });
+        await apiPost("action", { type:'USE', factory_code:factoryCode, lot_id:agg.lotId, flavor_id:agg.flavorId, payload:{ qty:useQty, location } });
+        if(onRemoteStorageRefresh){ await onRemoteStorageRefresh(); }
       } catch (err) {
         console.error(err);
       }
@@ -467,7 +741,8 @@ function StorageCardView({agg,onUse,onWaste,findFlavor,calcExpiry,factoryCode}:{
       await onWaste(wasteText,'other',location);
       if(USE_REMOTE){
         try {
-          await postAction({ path:'action', type:'WASTE', factory_code:factoryCode, lot_id:agg.lotId, flavor_id:agg.flavorId, payload:{ reason:'other', note:wasteText, location } });
+          await apiPost("action", { type:'WASTE', factory_code:factoryCode, lot_id:agg.lotId, flavor_id:agg.flavorId, payload:{ reason:'other', note:wasteText, location } });
+          if(onRemoteStorageRefresh){ await onRemoteStorageRefresh(); }
         } catch (err) {
           console.error(err);
         }
@@ -476,7 +751,8 @@ function StorageCardView({agg,onUse,onWaste,findFlavor,calcExpiry,factoryCode}:{
       await onWaste(wasteQty,wasteReason,location);
       if(USE_REMOTE){
         try {
-          await postAction({ path:'action', type:'WASTE', factory_code:factoryCode, lot_id:agg.lotId, flavor_id:agg.flavorId, payload:{ reason:wasteReason, qty:wasteQty, location } });
+          await apiPost("action", { type:'WASTE', factory_code:factoryCode, lot_id:agg.lotId, flavor_id:agg.flavorId, payload:{ reason:wasteReason, qty:wasteQty, location } });
+          if(onRemoteStorageRefresh){ await onRemoteStorageRefresh(); }
         } catch (err) {
           console.error(err);
         }

--- a/src/app/api/gas/[...path]/route.ts
+++ b/src/app/api/gas/[...path]/route.ts
@@ -1,0 +1,43 @@
+import type { NextRequest } from "next/server";
+
+const BASE = process.env.NEXT_PUBLIC_GAS_API_BASE!;
+const KEY = process.env.GAS_API_KEY!;
+
+function buildForwardUrl(base: string, searchParams: URLSearchParams) {
+  const query = searchParams.toString();
+  return query ? `${base}?${query}` : `${base}`;
+}
+
+export async function GET(req: NextRequest, { params }: { params: { path: string[] } }) {
+  const path = params.path.join("/");
+  const url = new URL(req.url);
+  url.searchParams.set("path", path);
+  url.searchParams.set("key", KEY);
+
+  const res = await fetch(buildForwardUrl(BASE, url.searchParams), {
+    cache: "no-store",
+  });
+  const txt = await res.text();
+
+  return new Response(txt, {
+    status: res.status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export async function POST(req: NextRequest, { params }: { params: { path: string[] } }) {
+  const path = params.path.join("/");
+  const body = await req.json().catch(() => ({}));
+
+  const res = await fetch(`${BASE}?key=${encodeURIComponent(KEY)}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ...body, path }),
+  });
+  const txt = await res.text();
+
+  return new Response(txt, {
+    status: res.status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/src/hooks/useMasters.ts
+++ b/src/hooks/useMasters.ts
@@ -1,0 +1,10 @@
+import useSWR from "swr";
+import { apiGet } from "@/lib/gas";
+import type { Masters } from "@/lib/sheets/types";
+
+export function useMasters(enabled = true) {
+  return useSWR(enabled ? ["masters"] : null, enabled ? () => apiGet<Masters>("masters") : null, {
+    revalidateOnFocus: false,
+    dedupingInterval: 30 * 60 * 1000,
+  });
+}

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -1,0 +1,11 @@
+import useSWR from "swr";
+import { apiGet } from "@/lib/gas";
+import type { OrderRow } from "@/lib/sheets/types";
+
+export function useOrders(factory?: string, archived = false) {
+  return useSWR(
+    factory ? ["orders", factory, archived] : null,
+    factory ? () => apiGet<OrderRow[]>("orders", { factory, archived }) : null,
+    { revalidateOnFocus: false },
+  );
+}

--- a/src/hooks/useStorageAgg.ts
+++ b/src/hooks/useStorageAgg.ts
@@ -1,0 +1,11 @@
+import useSWR from "swr";
+import { apiGet } from "@/lib/gas";
+import type { StorageAggRow } from "@/lib/sheets/types";
+
+export function useStorageAgg(factory?: string) {
+  return useSWR(
+    factory ? ["storage-agg", factory] : null,
+    factory ? () => apiGet<StorageAggRow[]>("storage-agg", { factory }) : null,
+    { revalidateOnFocus: false },
+  );
+}

--- a/src/lib/gas.ts
+++ b/src/lib/gas.ts
@@ -1,0 +1,26 @@
+export async function apiGet<T = unknown>(path: string, params?: Record<string, string | number | boolean>): Promise<T> {
+  const usp = new URLSearchParams();
+  Object.entries(params ?? {}).forEach(([key, value]) => {
+    usp.set(key, String(value));
+  });
+  const query = usp.toString();
+  const res = await fetch(query ? `/api/gas/${path}?${query}` : `/api/gas/${path}`, {
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return res.json();
+}
+
+export async function apiPost<T = unknown>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`/api/gas/${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body ?? {}),
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add a catch-all /api/gas proxy that forwards requests to the GAS Web App with the shared secret
- introduce a lightweight GAS client plus SWR hooks for masters, orders, and storage aggregation data
- wire the Office and Floor flows to the GAS endpoints for order creation and action logging while keeping local fallbacks

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68ca7eb1969c8329b9ea5697d4c8ef8a