### PR TITLE
Fix: GAS proxy + SWR wireup; build passes

### DIFF
--- a/src/app/api/gas/[...path]/route.ts
+++ b/src/app/api/gas/[...path]/route.ts
@@ -1,0 +1,35 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const BASE = process.env.NEXT_PUBLIC_GAS_API_BASE!;
+const KEY = process.env.GAS_API_KEY!;
+
+function buildTargetUrl(req: Request, pathSegments: string[]) {
+  const url = new URL(req.url);
+  url.searchParams.set("path", pathSegments.join("/"));
+  url.searchParams.set("key", KEY);
+  return `${BASE}?${url.searchParams.toString()}`;
+}
+
+export async function GET(req: Request, ctx: any) {
+  const path = Array.isArray(ctx?.params?.path) ? ctx?.params?.path : [];
+  const target = buildTargetUrl(req, path);
+  const res = await fetch(target, { cache: "no-store" });
+  return new Response(await res.text(), {
+    status: res.status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export async function POST(req: Request, ctx: any) {
+  const path = Array.isArray(ctx?.params?.path) ? ctx?.params?.path : [];
+  const body = await req.json().catch(() => ({}));
+  const target = `${BASE}?key=${encodeURIComponent(KEY)}`;
+  const res = await fetch(target, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ...body, path: path.join("/") }),
+  });
+  return new Response(await res.text(), {
+    status: res.status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/src/hooks/useMasters.ts
+++ b/src/hooks/useMasters.ts
@@ -1,0 +1,15 @@
+import useSWR from "swr";
+
+import { apiGet } from "@/lib/gas";
+import type { Masters } from "@/lib/sheets/types";
+
+export const mastersKey = "gas:masters" as const;
+
+export function useMasters(enabled = true) {
+  const key = enabled ? mastersKey : null;
+  return useSWR<Masters>(
+    key,
+    () => apiGet<Masters>("masters"),
+    { revalidateOnFocus: false, dedupingInterval: 30 * 60 * 1000 },
+  );
+}

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -1,0 +1,15 @@
+import useSWR from "swr";
+
+import { apiGet } from "@/lib/gas";
+import type { OrderRow } from "@/lib/sheets/types";
+
+export const ordersKey = (factory: string) => `gas:orders:${factory}`;
+
+export function useOrders(factory: string | undefined, enabled = true) {
+  const key = enabled && factory ? ordersKey(factory) : null;
+  return useSWR<OrderRow[]>(
+    key,
+    () => apiGet<OrderRow[]>("orders", { factory, archived: false }),
+    { revalidateOnFocus: false },
+  );
+}

--- a/src/hooks/useStorageAgg.ts
+++ b/src/hooks/useStorageAgg.ts
@@ -1,0 +1,15 @@
+import useSWR from "swr";
+
+import { apiGet } from "@/lib/gas";
+import type { StorageAggRow } from "@/lib/sheets/types";
+
+export const storageAggKey = (factory: string) => `gas:storage-agg:${factory}`;
+
+export function useStorageAgg(factory: string | undefined, enabled = true) {
+  const key = enabled && factory ? storageAggKey(factory) : null;
+  return useSWR<StorageAggRow[]>(
+    key,
+    () => apiGet<StorageAggRow[]>("storage-agg", { factory }),
+    { revalidateOnFocus: false },
+  );
+}

--- a/src/lib/gas.ts
+++ b/src/lib/gas.ts
@@ -1,0 +1,26 @@
+export async function apiGet<T = unknown>(path: string, params?: Record<string, unknown>): Promise<T> {
+  const usp = new URLSearchParams();
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value === undefined || value === null) return;
+    usp.set(key, String(value));
+  });
+  const query = usp.toString();
+  const url = query ? `/api/gas/${path}?${query}` : `/api/gas/${path}`;
+  const res = await fetch(url, { cache: "no-store" });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return res.json();
+}
+
+export async function apiPost<T = unknown>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`/api/gas/${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add `/api/gas/[...path]` proxy that uses the native `Request` type while allowing the route context to flow through so GAS calls work with the Vercel env vars
- introduce a thin GAS client (`apiGet`/`apiPost`) plus masters/orders/storage SWR hooks that call through the proxy
- update the prototype UI to send create/action/make requests via the proxy and revalidate the relevant SWR caches

## Testing
- `npm run build`

## Deployment
- Trigger a fresh Vercel deployment after merging so the new route handler is built and released.


------
https://chatgpt.com/codex/tasks/task_b_68ca9d323de883299a22d1a831dbb736