### PR TITLE
Use server bridge to GAS & load masters from GAS (remove sample data)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Google Apps Script endpoint configuration
+GAS_BASE_URL=
+GAS_API_KEY=

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,6 +1,3 @@
-NEXT_PUBLIC_USE_SHEETS=0
-NEXT_PUBLIC_SHEETS_API_BASE_URL=
-NEXT_PUBLIC_SHEETS_API_KEY=
-
-# We will point these to a Google Apps Script Web App that fronts Google Sheets
-# (Sheets = DB). Do not call any live API here; just wire the helpers.
+# Copy to .env.local and fill in your GAS deployment values for local development
+GAS_BASE_URL=
+GAS_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 !.env.local.example
 
 # vercel

--- a/README.md
+++ b/README.md
@@ -25,19 +25,18 @@ npm install
 
 ## Environment variables
 
-The front-end talks to Google Sheets via a Google Apps Script Web App.
+The application reads master/order/storage data from Google Sheets via a Google Apps Script Web App that is accessed **only** through the Next.js server.
 
 | Variable | Description |
 | --- | --- |
-| `NEXT_PUBLIC_USE_SHEETS` | Feature flag. Set to `1` to read/write via the Sheets Apps Script backend, otherwise the demo uses in-memory data. |
-| `NEXT_PUBLIC_SHEETS_API_BASE_URL` | Base URL of the Apps Script deployment that fronts Google Sheets. |
-| `NEXT_PUBLIC_SHEETS_API_KEY` | API key header (`x-api-key`) for the Apps Script gateway. |
+| `GAS_BASE_URL` | Base URL of the Google Apps Script deployment that fronts Google Sheets. The Next.js API route proxies all requests to this endpoint. |
+| `GAS_API_KEY` | API key stored in the GAS Script Properties. It is appended by the server bridge when forwarding requests. |
 
-> Never commit a real `.env.local` file to the repository; use `.env.local.example` as a reference.
+> Never commit a real `.env.local` file to the repository; use `.env.example` / `.env.local.example` as a reference.
 
-## Backend (Sheets API)
+## Backend (GAS bridge)
 
-The optional Sheets-backed mode fetches masters, orders, and storage data from your Google Apps Script deployment while logging actions (保管, 使用, 廃棄, 分割). Enable it by setting `NEXT_PUBLIC_USE_SHEETS=1` and configuring `NEXT_PUBLIC_SHEETS_API_BASE_URL` + `NEXT_PUBLIC_SHEETS_API_KEY` in both your local `.env.local` and the Vercel project settings.
+The server-side bridge (`/api/gas/*`) proxies GET/POST requests to the configured GAS deployment. Masters, orders, and storage data as well as action logging (保管, 使用, 廃棄, 分割) all flow through this bridge so that credentials never reach the browser.
 
 ## Prototype host
 
@@ -48,7 +47,7 @@ UI primitives (button, dialog, card, etc.) live in `src/components/ui` and are p
 ## Deployment on Vercel
 
 1. Create a new project in Vercel and connect it to the GitHub repository that hosts this code.
-2. Set `NEXT_PUBLIC_USE_SHEETS`, `NEXT_PUBLIC_SHEETS_API_BASE_URL`, and `NEXT_PUBLIC_SHEETS_API_KEY` inside the Vercel project settings.
+2. Set `GAS_BASE_URL` and `GAS_API_KEY` inside the Vercel project settings.
 3. Vercel will run `npm run build` (configured in `vercel.json`) to produce the production build.
 
 ## Next steps checklist

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "check:gas": "node -e \"fetch('http://localhost:3000/api/gas/masters').then(r=>r.status).then(s=>{if(s!==200)process.exit(1)})\""
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/src/lib/sheets/types.ts
+++ b/src/lib/sheets/types.ts
@@ -1,15 +1,19 @@
 export type UseType = 'fissule' | 'oem';
 
-export interface Factory { code: string; name: string }
-export interface Location { factory_code: string; location_name: string }
-export interface Flavor { id: string; flavorName: string; liquidName: string; packToGram: number; expiryDays: number }
 export interface RecipeRow { flavor_id: string; row_no: number; ingredient_name: string; qty: number; unit: string }
 export interface Masters {
-  factories: Factory[];
-  locations: Location[];
-  flavors: Flavor[];
+  factories: { factory_code: string; factory_name: string }[];
+  locations: { factory_code: string; location_name: string }[];
+  flavors: {
+    flavor_id: string;
+    flavor_name: string;
+    liquid_name: string;
+    pack_to_gram: number;
+    expiry_days: number;
+    barcode_code?: string;
+  }[];
   recipes: RecipeRow[];
-  oems: string[];
+  oem_partners: { partner_name: string }[];
 }
 
 export interface OrderRow {


### PR DESCRIPTION
## Summary
- add a Node runtime /api/gas bridge that proxies GET/POST requests to GAS using GAS_BASE_URL and GAS_API_KEY
- load factories, flavors, storage, and OEM data from the GAS masters endpoint (including loading/empty handling) and align types with the server response
- document the new environment variables, add .env example files, and include a script for a simple /api/gas/masters health check

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68ccd392ffc483298f673e3c5a55877c