### PR TITLE
fix(api): make route lint-clean & POST orders-create to GAS

### DIFF
--- a/src/app/(ui)/prototype/page.tsx
+++ b/src/app/(ui)/prototype/page.tsx
@@ -397,7 +397,8 @@ function Office({
             oem_partner: oemPartner,
             oem_grams: oemGrams,
           };
-    const body = {
+    const payload = {
+      path: "orders-create" as const,
       factory_code: factory,
       lot_id: lotId,
       ordered_at: orderedAt,
@@ -405,7 +406,7 @@ function Office({
     };
     try {
       setSubmitting(true);
-      await apiPost("orders-create", body);
+      await apiPost("action", payload);
       seqRef.current[key] = seq + 1;
       await mutate(["orders", factory, false]);
     } catch (error) {

--- a/src/app/api/gas/[...path]/route.ts
+++ b/src/app/api/gas/[...path]/route.ts
@@ -1,39 +1,85 @@
-// src/app/api/gas/[...path]/route.ts
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from "next/server";
 
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
 
-const BASE = process.env.GAS_BASE_URL!;
-const KEY  = process.env.GAS_API_KEY!;
+function getEnv(name: "GAS_BASE_URL" | "GAS_API_KEY"): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing environment variable: ${name}`);
+  }
+  return value;
+}
 
-export async function GET(req: NextRequest, context: any) {
-  const segs: string[] = Array.isArray(context?.params?.path) ? context.params.path : [];
-  const path = segs.join('/');
+const GAS_BASE_URL = getEnv("GAS_BASE_URL");
+const GAS_API_KEY = getEnv("GAS_API_KEY");
 
-  const url = new URL(req.url);
-  url.searchParams.delete('key'); // フロントからの key は無視
-  const qs = url.searchParams.toString();
-  const target =
-    `${BASE}?${path ? `path=${encodeURIComponent(path)}&` : ''}` +
-    `${qs ? `${qs}&` : ''}key=${KEY}`;
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
 
-  const r = await fetch(target, { cache: 'no-store' });
-  const text = await r.text();
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every(item => typeof item === "string");
+}
+
+function buildPath(params: { path?: string[] } | undefined): string {
+  if (!params) {
+    return "";
+  }
+  return isStringArray(params.path) ? params.path.join("/") : "";
+}
+
+async function relayJsonResponse(response: Response): Promise<NextResponse> {
+  const text = await response.text();
   return new NextResponse(text, {
-    status: r.status,
-    headers: { 'content-type': 'application/json' },
+    status: response.status,
+    headers: { "content-type": "application/json" },
   });
 }
 
-export async function POST(req: NextRequest) {
-  const r = await fetch(`${BASE}?key=${KEY}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: await req.text(),
+type RouteContext = { params?: { path?: string[] } };
+
+export async function GET(req: NextRequest, context: RouteContext): Promise<NextResponse> {
+  const path = buildPath(context.params);
+  const searchParams = new URLSearchParams(req.nextUrl.searchParams);
+  searchParams.delete("key");
+  if (path) {
+    searchParams.set("path", path);
+  }
+  searchParams.set("key", GAS_API_KEY);
+  const targetUrl = `${GAS_BASE_URL}?${searchParams.toString()}`;
+
+  const response = await fetch(targetUrl, { cache: "no-store" });
+  return relayJsonResponse(response);
+}
+
+export async function POST(req: NextRequest, context: RouteContext): Promise<NextResponse> {
+  const fallbackPath = buildPath(context.params);
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ message: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!isRecord(body)) {
+    return NextResponse.json({ message: "Request body must be a JSON object" }, { status: 400 });
+  }
+
+  const rawPath = typeof body.path === "string" ? body.path.trim() : "";
+  const resolvedPath = rawPath || fallbackPath;
+
+  if (!resolvedPath) {
+    return NextResponse.json({ message: "Missing path for GAS request" }, { status: 400 });
+  }
+
+  const payload: Record<string, unknown> = { ...body, path: resolvedPath };
+  const response = await fetch(`${GAS_BASE_URL}?key=${encodeURIComponent(GAS_API_KEY)}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+    cache: "no-store",
   });
-  const text = await r.text();
-  return new NextResponse(text, {
-    status: r.status,
-    headers: { 'content-type': 'application/json' },
-  });
+
+  return relayJsonResponse(response);
 }


### PR DESCRIPTION
## Summary
- harden the GAS API route with env guards, type-safe params, and ensure POST payloads always include a path before proxying
- adjust the prototype Office order creation flow to call the GAS action endpoint with path "orders-create"

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68ccfe848ba08329ad455960ac47449f