### PR TITLE
Fix GAS route params handling and orders create errors

### DIFF
--- a/src/app/(ui)/prototype/page.tsx
+++ b/src/app/(ui)/prototype/page.tsx
@@ -405,12 +405,19 @@ function Office({
           };
     try {
       setSubmitting(true);
-      await apiPost("orders-create", body);
+      const resp = await apiPost<{ ok?: boolean }>("orders-create", body);
+      if (!resp?.ok) {
+        throw new Error(JSON.stringify(resp));
+      }
       seqRef.current[key] = seq + 1;
       await mutate(["orders", factory, false]);
     } catch (error) {
       console.error(error);
-      alert("通信に失敗しました");
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : "通信に失敗しました";
+      alert(message);
     } finally {
       setSubmitting(false);
     }


### PR DESCRIPTION
## Summary
- normalize the GAS proxy route to accept `{ params }` while still resolving promise-based catch-all segments
- always merge the URL path into forwarded POST payloads to GAS
- send flat order payloads to `orders-create` and surface error responses directly in the UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d3a168d3288329bd81b546a68a39c3