### PR TITLE
Office: 右カラム見出しを『製造指示』にリネーム

### DIFF
--- a/src/app/(ui)/prototype/page.tsx
+++ b/src/app/(ui)/prototype/page.tsx
@@ -565,7 +565,7 @@ function Office({
       <Card className="shadow-sm">
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
-            <Package className="h-5 w-5" />進捗（未アーカイブ）
+            <Package className="h-5 w-5" />製造指示
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-3 max-h-[540px] overflow-auto pr-2">


### PR DESCRIPTION
## Summary
- rename the /office right-column card title from 「進捗（未アーカイブ）」 to 「製造指示」 for consistency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68df1ce3e9fc8329ae587ec61cb16522