### PR TITLE
Office: 3カラム化（作成｜保管在庫｜製造指示）& 在庫をFloor同等表示

### DIFF
--- a/src/app/(ui)/prototype/page.tsx
+++ b/src/app/(ui)/prototype/page.tsx
@@ -349,6 +349,21 @@ function Office({
   const ordersQuery = useOrders(factory || undefined, false);
   const orderCards = useMemo(() => normalizeOrders(ordersQuery.data), [ordersQuery.data]);
   const openOrders = useMemo(() => orderCards.filter(order => !order.archived), [orderCards]);
+  const storageAggQuery = useStorageAgg(factory || undefined);
+  const storageAgg = useMemo(() => normalizeStorage(storageAggQuery.data), [storageAggQuery.data]);
+
+  const calcExpiry = useCallback(
+    (manufacturedAt: string, flavorId: string) => {
+      const flavor = findFlavor(flavorId);
+      const days = flavor?.expiryDays ?? 0;
+      if (!manufacturedAt) return "-";
+      const d = new Date(manufacturedAt);
+      if (Number.isNaN(d.getTime())) return "-";
+      d.setDate(d.getDate() + days);
+      return format(d, "yyyy-MM-dd");
+    },
+    [findFlavor],
+  );
 
   useEffect(() => {
     const next = { ...seqRef.current };
@@ -424,7 +439,7 @@ function Office({
   }, [factory, flavor, useType, packs, oemPartner, oemGrams, findFlavor]);
 
   return (
-    <div className="grid md:grid-cols-2 gap-6">
+    <div className="grid md:grid-cols-3 gap-6 items-start">
       <Card className="shadow-sm">
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
@@ -562,10 +577,23 @@ function Office({
         </CardContent>
       </Card>
 
+      <KanbanColumn title="保管（在庫）" icon={<Warehouse className="h-4 w-4" />}>
+        {storageAgg.map(agg => (
+          <StorageCardView
+            key={agg.lotId}
+            agg={agg}
+            findFlavor={findFlavor}
+            calcExpiry={calcExpiry}
+            factoryCode={factory}
+          />
+        ))}
+        {storageAgg.length === 0 && <Empty>余剰の在庫はここに集計されます</Empty>}
+      </KanbanColumn>
+
       <Card className="shadow-sm">
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
-            <Package className="h-5 w-5" />進捗（未アーカイブ）
+            <Package className="h-5 w-5" />製造指示
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-3 max-h-[540px] overflow-auto pr-2">


### PR DESCRIPTION
目的: /office を3カラム化し、中央に『保管（在庫）』をFloorと同じ表示で追加しました。

主な変更:
- 外側レイアウトを md:grid-cols-3 に変更
- useStorageAgg/normalizeStorage をOfficeにも導入
- AppのcalcExpiryを簡易コピーしStorageCardViewに渡す
- 製造指示一覧は右カラムへ配置

参考: Floorの既存実装（在庫集計と表示）: :contentReference[oaicite:23]{index=23}, :contentReference[oaicite:24]{index=24}

影響範囲: UI構成のみ。既存APIやドメインロジックへの変更なし。

------
https://chatgpt.com/codex/tasks/task_b_68df1ce3e9fc8329ae587ec61cb16522