### PR TITLE
Show accurate remaining packs (uses GAS MADE_SPLIT progress)

### DIFF
--- a/src/lib/sheets/types.ts
+++ b/src/lib/sheets/types.ts
@@ -24,6 +24,8 @@ export interface OrderRow {
   flavor_id: string;
   use_type: UseType;
   packs: number;                // 0 if OEM
+  made_packs?: number;
+  packs_remaining?: number;
   required_grams: number;
   oem_partner?: string | null;
   archived: boolean;


### PR DESCRIPTION
## Summary
- Problem: remaining showed original packs even after MADE_SPLIT
- Solution: add packs_remaining from GAS and consume it in Floor
- Backwards compatibility: if GAS not yet updated, falls back to packs

------
https://chatgpt.com/codex/tasks/task_b_68df1ce3e9fc8329ae587ec61cb16522