### PR TITLE
Ensure storage card actions refresh storage display

### DIFF
--- a/src/lib/sheets/types.ts
+++ b/src/lib/sheets/types.ts
@@ -38,6 +38,7 @@ export interface StorageAggRow {
   grams: number;
   locations: string[];          // aggregated list
   manufactured_at: string;
+  packs_equiv?: number | null;
 }
 
 export interface ActionBody {


### PR DESCRIPTION
## Summary
- post USE/WASTE actions through the /exec endpoint and refresh related queries
- optimistically update storage card grams from the server response and show pack equivalents
- expose packs_equiv on storage aggregates and reuse shared formatting helpers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e3186bf1a88329b63458bb7085efe7