### PR TITLE
Fix: reporter selection & typing for action flows (clean from main)

### DIFF
--- a/src/app/(ui)/actions/extra/page.tsx
+++ b/src/app/(ui)/actions/extra/page.tsx
@@ -36,7 +36,7 @@ function ExtraActionPageInner() {
   const defaultFlavorParam = searchParams.get("flavor_id") ?? "";
 
   const mastersQuery = useMasters();
-  const { flavors, storageByFactory, oemList, uses, factories } = useMemo(
+  const { flavors, storageByFactory, oemList, uses, factories, reporters } = useMemo(
     () => deriveDataFromMasters(mastersQuery.data),
     [mastersQuery.data],
   );
@@ -78,6 +78,7 @@ function ExtraActionPageInner() {
     useCode: string,
     producedG: number,
     manufacturedAt: string,
+    reporter: string,
     oemPartner?: string,
     leftover?: { loc: string; grams: number },
     _lotId?: string,
@@ -102,6 +103,7 @@ function ExtraActionPageInner() {
       produced_grams: producedG,
       manufactured_at: manufacturedAt,
       oem_partner: useType === "oem" ? oemPartner ?? null : null,
+      by: reporter,
       leftover: leftover && leftover.grams > 0 ? { location: leftover.loc, grams: leftover.grams } : null,
       generated_lot_id: lotId,
       materials:
@@ -170,6 +172,7 @@ function ExtraActionPageInner() {
               storageByFactory={storageByFactory}
               mastersLoading={mastersQuery.isLoading || (!mastersQuery.data && !mastersQuery.error)}
               uses={uses}
+              reporters={reporters}
               onCancel={() => router.push(returnTo)}
             />
           </CardContent>

--- a/src/app/(ui)/actions/keep/page.tsx
+++ b/src/app/(ui)/actions/keep/page.tsx
@@ -26,7 +26,7 @@ function KeepActionPageInner() {
   const factoryParam = searchParams.get("factory") ?? "";
   const orderIdParam = searchParams.get("order_id") ?? "";
   const mastersQuery = useMasters();
-  const { storageByFactory, factories } = useMemo(
+  const { storageByFactory, factories, reporters } = useMemo(
     () => deriveDataFromMasters(mastersQuery.data),
     [mastersQuery.data],
   );
@@ -41,7 +41,7 @@ function KeepActionPageInner() {
   const requestIdRef = useRef<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const handleSubmit = async (values: KeepFormValues) => {
+  const handleSubmit = async (values: KeepFormValues, reporter: string) => {
     if (!targetOrder) return;
     const line = targetOrder.lines[0];
     if (!requestIdRef.current) {
@@ -63,6 +63,7 @@ function KeepActionPageInner() {
             grams: values.grams,
             manufactured_at: values.manufacturedAt,
           },
+          by: reporter,
         },
         { requestId },
       );
@@ -114,6 +115,7 @@ function KeepActionPageInner() {
                 storageByFactory={storageByFactory}
                 mastersLoading={mastersQuery.isLoading || (!mastersQuery.data && !mastersQuery.error)}
                 busy={busy}
+                reporters={reporters}
                 onSubmit={handleSubmit}
                 onCancel={() => router.push(returnTo)}
               />

--- a/src/app/(ui)/actions/made/page.tsx
+++ b/src/app/(ui)/actions/made/page.tsx
@@ -36,7 +36,7 @@ function MadeActionPageInner() {
   const initialMode = (searchParams.get("mode") as "bulk" | "split" | null) ?? "bulk";
 
   const mastersQuery = useMasters();
-  const { flavors, storageByFactory } = useMemo(
+  const { flavors, storageByFactory, reporters } = useMemo(
     () => deriveDataFromMasters(mastersQuery.data),
     [mastersQuery.data],
   );
@@ -68,7 +68,7 @@ function MadeActionPageInner() {
     return line.useType === "fissule" && (line.packs ?? 0) > 0;
   }, [targetOrder]);
 
-  const handleReportMade = async (report: MadeReport) => {
+  const handleReportMade = async (report: MadeReport, reporter: string) => {
     if (!targetOrder) return;
     const line = targetOrder.lines[0];
     const leftoverPayload =
@@ -102,13 +102,14 @@ function MadeActionPageInner() {
         "action",
         {
           type: "MADE_SPLIT",
-          factory_code: targetOrder.factoryCode,
-          lot_id: targetOrder.lotId,
-          flavor_id: line.flavorId,
-          payload: finalPayload,
-        },
-        { requestId },
-      );
+      factory_code: targetOrder.factoryCode,
+      lot_id: targetOrder.lotId,
+      flavor_id: line.flavorId,
+      payload: finalPayload,
+      by: reporter,
+    },
+    { requestId },
+  );
       await Promise.all([
         mutate(["orders", targetOrder.factoryCode, false]),
         mutate(["storage-agg", targetOrder.factoryCode]),
@@ -188,6 +189,7 @@ function MadeActionPageInner() {
                 storageByFactory={storageByFactory}
                 mastersLoading={mastersQuery.isLoading || (!mastersQuery.data && !mastersQuery.error)}
                 busy={busy}
+                reporters={reporters}
                 onCancel={() => router.push(returnTo)}
               />
             ) : (

--- a/src/lib/sheets/types.ts
+++ b/src/lib/sheets/types.ts
@@ -1,11 +1,19 @@
 export type UseType = 'fissule' | 'oem';
 
 export interface RecipeRow { flavor_id: string; row_no: number; ingredient_name: string; qty: number; unit: string }
+export interface ReporterRow {
+  reporter_id?: string | null;
+  reporter_name?: string | null;
+  factory_code?: string | null;
+  active?: string | number | null;
+  sort_order?: number | string | null;
+}
 export interface Masters {
   factories: { factory_code: string; factory_name: string }[];
   locations: { factory_code: string; location_name: string }[];
   uses?: { use_code: string; use_name: string; use_type: UseType }[];
   use_flavors?: { use_code: string; flavor_id: string }[];
+  reporters?: ReporterRow[];
   flavors: {
     flavor_id: string;
     flavor_name: string;


### PR DESCRIPTION
## Summary
- add typed reporter master rows and expose reporter lists to UI consumers
- require reporter selection on keep/made/extra action flows and pass the reporter via payload `by`
- extend shared types to cover reporter metadata while keeping factory-specific filtering in selection lists

## Testing
- npm run lint
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6953907fd8548329a694de54369b1f8e)