### PR TITLE
Fix use type mapping for OEM and Genkai use names

### DIFF
--- a/src/app/(ui)/prototype/shared.tsx
+++ b/src/app/(ui)/prototype/shared.tsx
@@ -175,20 +175,11 @@ export function deriveDataFromMasters(masters?: Masters): DerivedMastersData {
   const oemList = masters?.oem_partners?.map(partner => partner.partner_name) ?? [];
 
   const uses =
-    masters?.uses?.map(u => {
-      const name = (u.use_name ?? "").trim();
-      let type: UseType = u.use_type;
-      if (name === "OEM(送付分)") {
-        type = "fissule";
-      } else if (name === "玄海丼(送付分)" || name === "玄海丼(製造分)") {
-        type = "oem";
-      }
-      return {
-        code: u.use_code,
-        name: u.use_name,
-        type,
-      };
-    }) ?? [];
+    masters?.uses?.map(u => ({
+      code: u.use_code,
+      name: u.use_name,
+      type: u.use_type,
+    })) ?? [];
 
   const allowedByUse: Record<string, Set<string>> = {};
   masters?.use_flavors?.forEach(row => {

--- a/src/app/(ui)/prototype/shared.tsx
+++ b/src/app/(ui)/prototype/shared.tsx
@@ -175,11 +175,20 @@ export function deriveDataFromMasters(masters?: Masters): DerivedMastersData {
   const oemList = masters?.oem_partners?.map(partner => partner.partner_name) ?? [];
 
   const uses =
-    masters?.uses?.map(u => ({
-      code: u.use_code,
-      name: u.use_name,
-      type: u.use_type,
-    })) ?? [];
+    masters?.uses?.map(u => {
+      const name = (u.use_name ?? "").trim();
+      let type: UseType = u.use_type;
+      if (name === "OEM(送付分)") {
+        type = "fissule";
+      } else if (name === "玄海丼(送付分)" || name === "玄海丼(製造分)") {
+        type = "oem";
+      }
+      return {
+        code: u.use_code,
+        name: u.use_name,
+        type,
+      };
+    }) ?? [];
 
   const allowedByUse: Record<string, Set<string>> = {};
   masters?.use_flavors?.forEach(row => {


### PR DESCRIPTION
### Motivation
- The UI input switching for manufacturing instruction tickets was reversed for specific `use` selections, causing the wrong input fields to appear.
- The desired behavior is that `玄海丼(送付分)` and `玄海丼(製造分)` behave as `oem` and `OEM(送付分)` behaves as `fissule`.
- The change must be minimal and only touch the mapping logic in `deriveDataFromMasters`.
- The fix must preserve TypeScript compatibility with the `UseType` type.

### Description
- Modify the `masters?.uses?.map(...)` block inside `deriveDataFromMasters()` in `src/app/(ui)/prototype/shared.tsx` to compute `name` as `u.use_name.trim()` and start `type` from `u.use_type`.
- Override `type` to `"fissule"` when `name === "OEM(送付分)"` and to `"oem"` when `name === "玄海丼(送付分)" || name === "玄海丼(製造分)"`.
- Return objects in the shape `{ code: u.use_code, name: u.use_name, type }` while keeping other entries unchanged.
- The change is restricted to that single mapping expression and uses the `UseType` annotation to avoid type errors.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695c562f1ea08329a10ff63fadb686e4)